### PR TITLE
Support repeated fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+protoc/protoc.exe
+protoc/include

--- a/protobuf2arr/serializer.py
+++ b/protobuf2arr/serializer.py
@@ -1,6 +1,7 @@
+from asyncio.log import logger
 from pickletools import long1
 import simplejson as json
-from typing import Any, List
+from typing import Any, Callable, List
 from google.protobuf.message import Message
 from google.protobuf.descriptor import FieldDescriptor
 
@@ -40,7 +41,8 @@ def msg_to_arr(obj: Message) -> List[Any]:
                 val = None
             elif str(val) in default_values:
                 val = None
-
+        if field.label == field.LABEL_REPEATED and val != None:
+            val = [item for item in val]
         result.append(val)
     return result
 
@@ -60,8 +62,7 @@ def arr_to_msg(arr: List[Any], msg: Message) -> Message:
                         field_val.append(arr_to_msg(sub_item_vals, sub_item_cls))
                     else:
                         field_val.append(arr_to_msg(sub_item, cls()))
-                ls = getattr(msg, field.name)
-                ls.extend(field_val)
+                _assign_list_field(msg, field, field_val)
             else:
                 arr_to_msg(item, getattr(msg, field.name))
         elif field.type == field.TYPE_BYTES and isinstance(item, str):
@@ -78,23 +79,36 @@ def arr_to_msg(arr: List[Any], msg: Message) -> Message:
                 )
             )
             typed_value = _str_to_type(field, default_value)
-            setattr(msg, field.name, typed_value)
+            _assign_list_field(msg, field, typed_value)
         else:
             setattr(msg, field.name, item)
     return msg
 
+def _assign_list_field(msg: Message, field: FieldDescriptor, value: List[Any]) -> None:
+    if field.label == field.LABEL_REPEATED and isinstance(value, list):
+        ls = getattr(msg, field.name)
+        ls.extend(value)
+    else:
+        setattr(msg, field.name, value)
 
 def _str_to_type(field: FieldDescriptor, value: str) -> Any:
+    value_arr: List[Any] = None
+    if field.label == field.LABEL_REPEATED:
+        try:
+            value_arr = json.loads(value)
+        except:
+            logger.warn("Invalid default value for repeated field: " + field.name)
+
     if field.type == field.TYPE_STRING:
-        return value
+        return value if value_arr is None else value_arr
     elif field.type == field.TYPE_BOOL:
-        return value.lower() in ["true", "1", "yes"]
+        return value.lower() in ["true", "1", "yes"]  if value_arr is None else value_arr
     elif field.type == field.TYPE_BYTES:
-        return value.encode("UTF-8")
+        return value.encode("UTF-8") if value_arr is None else value_arr
     elif field.type == field.TYPE_ENUM:
-        return int(value)
+        return int(value) if value_arr is None else value_arr
     elif field.type == field.TYPE_DOUBLE or field.type == field.TYPE_FLOAT:
-        return float(value)
+        return float(value) if value_arr is None else value_arr
     elif field.type in [
         field.TYPE_FIXED32,
         field.TYPE_FIXED64,
@@ -107,9 +121,9 @@ def _str_to_type(field: FieldDescriptor, value: str) -> Any:
         field.TYPE_UINT32,
         field.TYPE_UINT64,
     ]:
-        return int(value)
+        return int(value) if value_arr is None else value_arr
     else:
-        return None
+        return None if value_arr is None else value_arr
 
 
 def serialize_msg2arr(message: Message) -> str:

--- a/protobuf2arr/serializer.py
+++ b/protobuf2arr/serializer.py
@@ -1,7 +1,6 @@
 from asyncio.log import logger
-from pickletools import long1
 import simplejson as json
-from typing import Any, Callable, List
+from typing import Any, List
 from google.protobuf.message import Message
 from google.protobuf.descriptor import FieldDescriptor
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "protobuf2arr"
-version = "0.1.1"
+version = "0.1.2"
 description = "Translate a protobuf message to Google's RPC array format."
 authors = ["Kevin Ramdath <krpent@gmail.com>"]
 repository = "https://github.com/minormending/protobuf2arr"

--- a/tests/test_basic.proto
+++ b/tests/test_basic.proto
@@ -21,8 +21,9 @@ message TestQueue {
     bool field_bool = 4 [(nullable) = 'False'];
     bytes field_bytes = 5 [(nullable) = ''];
     TestEnum field_enum = 6 [(nullable) = '0'];
+    repeated int32 repeated_int = 7 [(nullable) = '[]'];
 
-    repeated TestItem items = 7 [(nullable) = ''];
+    repeated TestItem items = 8 [(nullable) = ''];
 
     message TestItem {
         int32 item_field_int = 1 [(nullable) = '0'];

--- a/tests/test_basic_pb2.py
+++ b/tests/test_basic_pb2.py
@@ -6,7 +6,6 @@ from google.protobuf.internal import builder as _builder
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import symbol_database as _symbol_database
-
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -15,62 +14,46 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import descriptor_pb2 as google_dot_protobuf_dot_descriptor__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x10test_basic.proto\x12\x0ctest_default\x1a google/protobuf/descriptor.proto"\xc4\x04\n\tTestQueue\x12\x18\n\tfield_int\x18\x01 \x01(\x05\x42\x05\xda\xb6\x18\x01\x30\x12\x1d\n\x0c\x66ield_double\x18\x02 \x01(\x01\x42\x07\xda\xb6\x18\x03\x30.0\x12\x1a\n\x0c\x66ield_string\x18\x03 \x01(\tB\x04\xda\xb6\x18\x00\x12\x1d\n\nfield_bool\x18\x04 \x01(\x08\x42\t\xda\xb6\x18\x05\x46\x61lse\x12\x19\n\x0b\x66ield_bytes\x18\x05 \x01(\x0c\x42\x04\xda\xb6\x18\x00\x12;\n\nfield_enum\x18\x06 \x01(\x0e\x32 .test_default.TestQueue.TestEnumB\x05\xda\xb6\x18\x01\x30\x12\x35\n\x05items\x18\x07 \x03(\x0b\x32 .test_default.TestQueue.TestItemB\x04\xda\xb6\x18\x00\x1a\xf4\x01\n\x08TestItem\x12\x1d\n\x0eitem_field_int\x18\x01 \x01(\x05\x42\x05\xda\xb6\x18\x01\x30\x12"\n\x11item_field_double\x18\x02 \x01(\x01\x42\x07\xda\xb6\x18\x03\x30.0\x12\x1f\n\x11item_field_string\x18\x03 \x01(\tB\x04\xda\xb6\x18\x00\x12"\n\x0fitem_field_bool\x18\x04 \x01(\x08\x42\t\xda\xb6\x18\x05\x46\x61lse\x12\x1e\n\x10item_field_bytes\x18\x05 \x01(\x0c\x42\x04\xda\xb6\x18\x00\x12@\n\x0fitem_field_enum\x18\x06 \x01(\x0e\x32 .test_default.TestQueue.TestEnumB\x05\xda\xb6\x18\x01\x30"=\n\x08TestEnum\x12\x0f\n\x0bTEST_ENUM_0\x10\x00\x12\x0f\n\x0bTEST_ENUM_1\x10\x01\x12\x0f\n\x0bTEST_ENUM_2\x10\x02:4\n\x08nullable\x12\x1d.google.protobuf.FieldOptions\x18\xeb\x86\x03 \x01(\t\x88\x01\x01\x62\x06proto3'
-)
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x10test_basic.proto\x12\x0ctest_default\x1a google/protobuf/descriptor.proto\"\xe2\x04\n\tTestQueue\x12\x18\n\tfield_int\x18\x01 \x01(\x05\x42\x05\xda\xb6\x18\x01\x30\x12\x1d\n\x0c\x66ield_double\x18\x02 \x01(\x01\x42\x07\xda\xb6\x18\x03\x30.0\x12\x1a\n\x0c\x66ield_string\x18\x03 \x01(\tB\x04\xda\xb6\x18\x00\x12\x1d\n\nfield_bool\x18\x04 \x01(\x08\x42\t\xda\xb6\x18\x05\x46\x61lse\x12\x19\n\x0b\x66ield_bytes\x18\x05 \x01(\x0c\x42\x04\xda\xb6\x18\x00\x12;\n\nfield_enum\x18\x06 \x01(\x0e\x32 .test_default.TestQueue.TestEnumB\x05\xda\xb6\x18\x01\x30\x12\x1c\n\x0crepeated_int\x18\x07 \x03(\x05\x42\x06\xda\xb6\x18\x02[]\x12\x35\n\x05items\x18\x08 \x03(\x0b\x32 .test_default.TestQueue.TestItemB\x04\xda\xb6\x18\x00\x1a\xf4\x01\n\x08TestItem\x12\x1d\n\x0eitem_field_int\x18\x01 \x01(\x05\x42\x05\xda\xb6\x18\x01\x30\x12\"\n\x11item_field_double\x18\x02 \x01(\x01\x42\x07\xda\xb6\x18\x03\x30.0\x12\x1f\n\x11item_field_string\x18\x03 \x01(\tB\x04\xda\xb6\x18\x00\x12\"\n\x0fitem_field_bool\x18\x04 \x01(\x08\x42\t\xda\xb6\x18\x05\x46\x61lse\x12\x1e\n\x10item_field_bytes\x18\x05 \x01(\x0c\x42\x04\xda\xb6\x18\x00\x12@\n\x0fitem_field_enum\x18\x06 \x01(\x0e\x32 .test_default.TestQueue.TestEnumB\x05\xda\xb6\x18\x01\x30\"=\n\x08TestEnum\x12\x0f\n\x0bTEST_ENUM_0\x10\x00\x12\x0f\n\x0bTEST_ENUM_1\x10\x01\x12\x0f\n\x0bTEST_ENUM_2\x10\x02:4\n\x08nullable\x12\x1d.google.protobuf.FieldOptions\x18\xeb\x86\x03 \x01(\t\x88\x01\x01\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
-_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "test_basic_pb2", globals())
+_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'test_basic_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
-    google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(nullable)
+  google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(nullable)
 
-    DESCRIPTOR._options = None
-    _TESTQUEUE_TESTITEM.fields_by_name["item_field_int"]._options = None
-    _TESTQUEUE_TESTITEM.fields_by_name[
-        "item_field_int"
-    ]._serialized_options = b"\332\266\030\0010"
-    _TESTQUEUE_TESTITEM.fields_by_name["item_field_double"]._options = None
-    _TESTQUEUE_TESTITEM.fields_by_name[
-        "item_field_double"
-    ]._serialized_options = b"\332\266\030\0030.0"
-    _TESTQUEUE_TESTITEM.fields_by_name["item_field_string"]._options = None
-    _TESTQUEUE_TESTITEM.fields_by_name[
-        "item_field_string"
-    ]._serialized_options = b"\332\266\030\000"
-    _TESTQUEUE_TESTITEM.fields_by_name["item_field_bool"]._options = None
-    _TESTQUEUE_TESTITEM.fields_by_name[
-        "item_field_bool"
-    ]._serialized_options = b"\332\266\030\005False"
-    _TESTQUEUE_TESTITEM.fields_by_name["item_field_bytes"]._options = None
-    _TESTQUEUE_TESTITEM.fields_by_name[
-        "item_field_bytes"
-    ]._serialized_options = b"\332\266\030\000"
-    _TESTQUEUE_TESTITEM.fields_by_name["item_field_enum"]._options = None
-    _TESTQUEUE_TESTITEM.fields_by_name[
-        "item_field_enum"
-    ]._serialized_options = b"\332\266\030\0010"
-    _TESTQUEUE.fields_by_name["field_int"]._options = None
-    _TESTQUEUE.fields_by_name["field_int"]._serialized_options = b"\332\266\030\0010"
-    _TESTQUEUE.fields_by_name["field_double"]._options = None
-    _TESTQUEUE.fields_by_name[
-        "field_double"
-    ]._serialized_options = b"\332\266\030\0030.0"
-    _TESTQUEUE.fields_by_name["field_string"]._options = None
-    _TESTQUEUE.fields_by_name["field_string"]._serialized_options = b"\332\266\030\000"
-    _TESTQUEUE.fields_by_name["field_bool"]._options = None
-    _TESTQUEUE.fields_by_name[
-        "field_bool"
-    ]._serialized_options = b"\332\266\030\005False"
-    _TESTQUEUE.fields_by_name["field_bytes"]._options = None
-    _TESTQUEUE.fields_by_name["field_bytes"]._serialized_options = b"\332\266\030\000"
-    _TESTQUEUE.fields_by_name["field_enum"]._options = None
-    _TESTQUEUE.fields_by_name["field_enum"]._serialized_options = b"\332\266\030\0010"
-    _TESTQUEUE.fields_by_name["items"]._options = None
-    _TESTQUEUE.fields_by_name["items"]._serialized_options = b"\332\266\030\000"
-    _TESTQUEUE._serialized_start = 69
-    _TESTQUEUE._serialized_end = 649
-    _TESTQUEUE_TESTITEM._serialized_start = 342
-    _TESTQUEUE_TESTITEM._serialized_end = 586
-    _TESTQUEUE_TESTENUM._serialized_start = 588
-    _TESTQUEUE_TESTENUM._serialized_end = 649
+  DESCRIPTOR._options = None
+  _TESTQUEUE_TESTITEM.fields_by_name['item_field_int']._options = None
+  _TESTQUEUE_TESTITEM.fields_by_name['item_field_int']._serialized_options = b'\332\266\030\0010'
+  _TESTQUEUE_TESTITEM.fields_by_name['item_field_double']._options = None
+  _TESTQUEUE_TESTITEM.fields_by_name['item_field_double']._serialized_options = b'\332\266\030\0030.0'
+  _TESTQUEUE_TESTITEM.fields_by_name['item_field_string']._options = None
+  _TESTQUEUE_TESTITEM.fields_by_name['item_field_string']._serialized_options = b'\332\266\030\000'
+  _TESTQUEUE_TESTITEM.fields_by_name['item_field_bool']._options = None
+  _TESTQUEUE_TESTITEM.fields_by_name['item_field_bool']._serialized_options = b'\332\266\030\005False'
+  _TESTQUEUE_TESTITEM.fields_by_name['item_field_bytes']._options = None
+  _TESTQUEUE_TESTITEM.fields_by_name['item_field_bytes']._serialized_options = b'\332\266\030\000'
+  _TESTQUEUE_TESTITEM.fields_by_name['item_field_enum']._options = None
+  _TESTQUEUE_TESTITEM.fields_by_name['item_field_enum']._serialized_options = b'\332\266\030\0010'
+  _TESTQUEUE.fields_by_name['field_int']._options = None
+  _TESTQUEUE.fields_by_name['field_int']._serialized_options = b'\332\266\030\0010'
+  _TESTQUEUE.fields_by_name['field_double']._options = None
+  _TESTQUEUE.fields_by_name['field_double']._serialized_options = b'\332\266\030\0030.0'
+  _TESTQUEUE.fields_by_name['field_string']._options = None
+  _TESTQUEUE.fields_by_name['field_string']._serialized_options = b'\332\266\030\000'
+  _TESTQUEUE.fields_by_name['field_bool']._options = None
+  _TESTQUEUE.fields_by_name['field_bool']._serialized_options = b'\332\266\030\005False'
+  _TESTQUEUE.fields_by_name['field_bytes']._options = None
+  _TESTQUEUE.fields_by_name['field_bytes']._serialized_options = b'\332\266\030\000'
+  _TESTQUEUE.fields_by_name['field_enum']._options = None
+  _TESTQUEUE.fields_by_name['field_enum']._serialized_options = b'\332\266\030\0010'
+  _TESTQUEUE.fields_by_name['repeated_int']._options = None
+  _TESTQUEUE.fields_by_name['repeated_int']._serialized_options = b'\332\266\030\002[]'
+  _TESTQUEUE.fields_by_name['items']._options = None
+  _TESTQUEUE.fields_by_name['items']._serialized_options = b'\332\266\030\000'
+  _TESTQUEUE._serialized_start=69
+  _TESTQUEUE._serialized_end=679
+  _TESTQUEUE_TESTITEM._serialized_start=372
+  _TESTQUEUE_TESTITEM._serialized_end=616
+  _TESTQUEUE_TESTENUM._serialized_start=618
+  _TESTQUEUE_TESTENUM._serialized_end=679
 # @@protoc_insertion_point(module_scope)

--- a/tests/test_basic_pb2.py
+++ b/tests/test_basic_pb2.py
@@ -6,6 +6,7 @@ from google.protobuf.internal import builder as _builder
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import symbol_database as _symbol_database
+
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -14,46 +15,66 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import descriptor_pb2 as google_dot_protobuf_dot_descriptor__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x10test_basic.proto\x12\x0ctest_default\x1a google/protobuf/descriptor.proto\"\xe2\x04\n\tTestQueue\x12\x18\n\tfield_int\x18\x01 \x01(\x05\x42\x05\xda\xb6\x18\x01\x30\x12\x1d\n\x0c\x66ield_double\x18\x02 \x01(\x01\x42\x07\xda\xb6\x18\x03\x30.0\x12\x1a\n\x0c\x66ield_string\x18\x03 \x01(\tB\x04\xda\xb6\x18\x00\x12\x1d\n\nfield_bool\x18\x04 \x01(\x08\x42\t\xda\xb6\x18\x05\x46\x61lse\x12\x19\n\x0b\x66ield_bytes\x18\x05 \x01(\x0c\x42\x04\xda\xb6\x18\x00\x12;\n\nfield_enum\x18\x06 \x01(\x0e\x32 .test_default.TestQueue.TestEnumB\x05\xda\xb6\x18\x01\x30\x12\x1c\n\x0crepeated_int\x18\x07 \x03(\x05\x42\x06\xda\xb6\x18\x02[]\x12\x35\n\x05items\x18\x08 \x03(\x0b\x32 .test_default.TestQueue.TestItemB\x04\xda\xb6\x18\x00\x1a\xf4\x01\n\x08TestItem\x12\x1d\n\x0eitem_field_int\x18\x01 \x01(\x05\x42\x05\xda\xb6\x18\x01\x30\x12\"\n\x11item_field_double\x18\x02 \x01(\x01\x42\x07\xda\xb6\x18\x03\x30.0\x12\x1f\n\x11item_field_string\x18\x03 \x01(\tB\x04\xda\xb6\x18\x00\x12\"\n\x0fitem_field_bool\x18\x04 \x01(\x08\x42\t\xda\xb6\x18\x05\x46\x61lse\x12\x1e\n\x10item_field_bytes\x18\x05 \x01(\x0c\x42\x04\xda\xb6\x18\x00\x12@\n\x0fitem_field_enum\x18\x06 \x01(\x0e\x32 .test_default.TestQueue.TestEnumB\x05\xda\xb6\x18\x01\x30\"=\n\x08TestEnum\x12\x0f\n\x0bTEST_ENUM_0\x10\x00\x12\x0f\n\x0bTEST_ENUM_1\x10\x01\x12\x0f\n\x0bTEST_ENUM_2\x10\x02:4\n\x08nullable\x12\x1d.google.protobuf.FieldOptions\x18\xeb\x86\x03 \x01(\t\x88\x01\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
+    b'\n\x10test_basic.proto\x12\x0ctest_default\x1a google/protobuf/descriptor.proto"\xe2\x04\n\tTestQueue\x12\x18\n\tfield_int\x18\x01 \x01(\x05\x42\x05\xda\xb6\x18\x01\x30\x12\x1d\n\x0c\x66ield_double\x18\x02 \x01(\x01\x42\x07\xda\xb6\x18\x03\x30.0\x12\x1a\n\x0c\x66ield_string\x18\x03 \x01(\tB\x04\xda\xb6\x18\x00\x12\x1d\n\nfield_bool\x18\x04 \x01(\x08\x42\t\xda\xb6\x18\x05\x46\x61lse\x12\x19\n\x0b\x66ield_bytes\x18\x05 \x01(\x0c\x42\x04\xda\xb6\x18\x00\x12;\n\nfield_enum\x18\x06 \x01(\x0e\x32 .test_default.TestQueue.TestEnumB\x05\xda\xb6\x18\x01\x30\x12\x1c\n\x0crepeated_int\x18\x07 \x03(\x05\x42\x06\xda\xb6\x18\x02[]\x12\x35\n\x05items\x18\x08 \x03(\x0b\x32 .test_default.TestQueue.TestItemB\x04\xda\xb6\x18\x00\x1a\xf4\x01\n\x08TestItem\x12\x1d\n\x0eitem_field_int\x18\x01 \x01(\x05\x42\x05\xda\xb6\x18\x01\x30\x12"\n\x11item_field_double\x18\x02 \x01(\x01\x42\x07\xda\xb6\x18\x03\x30.0\x12\x1f\n\x11item_field_string\x18\x03 \x01(\tB\x04\xda\xb6\x18\x00\x12"\n\x0fitem_field_bool\x18\x04 \x01(\x08\x42\t\xda\xb6\x18\x05\x46\x61lse\x12\x1e\n\x10item_field_bytes\x18\x05 \x01(\x0c\x42\x04\xda\xb6\x18\x00\x12@\n\x0fitem_field_enum\x18\x06 \x01(\x0e\x32 .test_default.TestQueue.TestEnumB\x05\xda\xb6\x18\x01\x30"=\n\x08TestEnum\x12\x0f\n\x0bTEST_ENUM_0\x10\x00\x12\x0f\n\x0bTEST_ENUM_1\x10\x01\x12\x0f\n\x0bTEST_ENUM_2\x10\x02:4\n\x08nullable\x12\x1d.google.protobuf.FieldOptions\x18\xeb\x86\x03 \x01(\t\x88\x01\x01\x62\x06proto3'
+)
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
-_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'test_basic_pb2', globals())
+_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "test_basic_pb2", globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
-  google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(nullable)
+    google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(nullable)
 
-  DESCRIPTOR._options = None
-  _TESTQUEUE_TESTITEM.fields_by_name['item_field_int']._options = None
-  _TESTQUEUE_TESTITEM.fields_by_name['item_field_int']._serialized_options = b'\332\266\030\0010'
-  _TESTQUEUE_TESTITEM.fields_by_name['item_field_double']._options = None
-  _TESTQUEUE_TESTITEM.fields_by_name['item_field_double']._serialized_options = b'\332\266\030\0030.0'
-  _TESTQUEUE_TESTITEM.fields_by_name['item_field_string']._options = None
-  _TESTQUEUE_TESTITEM.fields_by_name['item_field_string']._serialized_options = b'\332\266\030\000'
-  _TESTQUEUE_TESTITEM.fields_by_name['item_field_bool']._options = None
-  _TESTQUEUE_TESTITEM.fields_by_name['item_field_bool']._serialized_options = b'\332\266\030\005False'
-  _TESTQUEUE_TESTITEM.fields_by_name['item_field_bytes']._options = None
-  _TESTQUEUE_TESTITEM.fields_by_name['item_field_bytes']._serialized_options = b'\332\266\030\000'
-  _TESTQUEUE_TESTITEM.fields_by_name['item_field_enum']._options = None
-  _TESTQUEUE_TESTITEM.fields_by_name['item_field_enum']._serialized_options = b'\332\266\030\0010'
-  _TESTQUEUE.fields_by_name['field_int']._options = None
-  _TESTQUEUE.fields_by_name['field_int']._serialized_options = b'\332\266\030\0010'
-  _TESTQUEUE.fields_by_name['field_double']._options = None
-  _TESTQUEUE.fields_by_name['field_double']._serialized_options = b'\332\266\030\0030.0'
-  _TESTQUEUE.fields_by_name['field_string']._options = None
-  _TESTQUEUE.fields_by_name['field_string']._serialized_options = b'\332\266\030\000'
-  _TESTQUEUE.fields_by_name['field_bool']._options = None
-  _TESTQUEUE.fields_by_name['field_bool']._serialized_options = b'\332\266\030\005False'
-  _TESTQUEUE.fields_by_name['field_bytes']._options = None
-  _TESTQUEUE.fields_by_name['field_bytes']._serialized_options = b'\332\266\030\000'
-  _TESTQUEUE.fields_by_name['field_enum']._options = None
-  _TESTQUEUE.fields_by_name['field_enum']._serialized_options = b'\332\266\030\0010'
-  _TESTQUEUE.fields_by_name['repeated_int']._options = None
-  _TESTQUEUE.fields_by_name['repeated_int']._serialized_options = b'\332\266\030\002[]'
-  _TESTQUEUE.fields_by_name['items']._options = None
-  _TESTQUEUE.fields_by_name['items']._serialized_options = b'\332\266\030\000'
-  _TESTQUEUE._serialized_start=69
-  _TESTQUEUE._serialized_end=679
-  _TESTQUEUE_TESTITEM._serialized_start=372
-  _TESTQUEUE_TESTITEM._serialized_end=616
-  _TESTQUEUE_TESTENUM._serialized_start=618
-  _TESTQUEUE_TESTENUM._serialized_end=679
+    DESCRIPTOR._options = None
+    _TESTQUEUE_TESTITEM.fields_by_name["item_field_int"]._options = None
+    _TESTQUEUE_TESTITEM.fields_by_name[
+        "item_field_int"
+    ]._serialized_options = b"\332\266\030\0010"
+    _TESTQUEUE_TESTITEM.fields_by_name["item_field_double"]._options = None
+    _TESTQUEUE_TESTITEM.fields_by_name[
+        "item_field_double"
+    ]._serialized_options = b"\332\266\030\0030.0"
+    _TESTQUEUE_TESTITEM.fields_by_name["item_field_string"]._options = None
+    _TESTQUEUE_TESTITEM.fields_by_name[
+        "item_field_string"
+    ]._serialized_options = b"\332\266\030\000"
+    _TESTQUEUE_TESTITEM.fields_by_name["item_field_bool"]._options = None
+    _TESTQUEUE_TESTITEM.fields_by_name[
+        "item_field_bool"
+    ]._serialized_options = b"\332\266\030\005False"
+    _TESTQUEUE_TESTITEM.fields_by_name["item_field_bytes"]._options = None
+    _TESTQUEUE_TESTITEM.fields_by_name[
+        "item_field_bytes"
+    ]._serialized_options = b"\332\266\030\000"
+    _TESTQUEUE_TESTITEM.fields_by_name["item_field_enum"]._options = None
+    _TESTQUEUE_TESTITEM.fields_by_name[
+        "item_field_enum"
+    ]._serialized_options = b"\332\266\030\0010"
+    _TESTQUEUE.fields_by_name["field_int"]._options = None
+    _TESTQUEUE.fields_by_name["field_int"]._serialized_options = b"\332\266\030\0010"
+    _TESTQUEUE.fields_by_name["field_double"]._options = None
+    _TESTQUEUE.fields_by_name[
+        "field_double"
+    ]._serialized_options = b"\332\266\030\0030.0"
+    _TESTQUEUE.fields_by_name["field_string"]._options = None
+    _TESTQUEUE.fields_by_name["field_string"]._serialized_options = b"\332\266\030\000"
+    _TESTQUEUE.fields_by_name["field_bool"]._options = None
+    _TESTQUEUE.fields_by_name[
+        "field_bool"
+    ]._serialized_options = b"\332\266\030\005False"
+    _TESTQUEUE.fields_by_name["field_bytes"]._options = None
+    _TESTQUEUE.fields_by_name["field_bytes"]._serialized_options = b"\332\266\030\000"
+    _TESTQUEUE.fields_by_name["field_enum"]._options = None
+    _TESTQUEUE.fields_by_name["field_enum"]._serialized_options = b"\332\266\030\0010"
+    _TESTQUEUE.fields_by_name["repeated_int"]._options = None
+    _TESTQUEUE.fields_by_name[
+        "repeated_int"
+    ]._serialized_options = b"\332\266\030\002[]"
+    _TESTQUEUE.fields_by_name["items"]._options = None
+    _TESTQUEUE.fields_by_name["items"]._serialized_options = b"\332\266\030\000"
+    _TESTQUEUE._serialized_start = 69
+    _TESTQUEUE._serialized_end = 679
+    _TESTQUEUE_TESTITEM._serialized_start = 372
+    _TESTQUEUE_TESTITEM._serialized_end = 616
+    _TESTQUEUE_TESTENUM._serialized_start = 618
+    _TESTQUEUE_TESTENUM._serialized_end = 679
 # @@protoc_insertion_point(module_scope)

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -32,7 +32,7 @@ class TestSerializer(TestCase):
         self.assertEqual(serial, "[null,null,null,null,null,null,null,[]]")
 
         self._test_deserialization(queue, arr, serial, TestQueueBasic)
-"""
+
     def test_serialization_basic_default_empty_subitems(self):
         queue = TestQueueBasic()
         queue.items.append(TestQueueBasic.TestItem())
@@ -52,6 +52,8 @@ class TestSerializer(TestCase):
         queue.field_bool = False
         queue.field_bytes = b""
         queue.field_enum = TestQueueBasic.TestEnum.TEST_ENUM_0
+        queue.repeated_int.append(1)
+        queue.repeated_int.pop()
 
         arr = msg_to_arr(queue)
         self.assertEqual(arr, [None, None, None, None, None, None, None, []])
@@ -69,12 +71,16 @@ class TestSerializer(TestCase):
         queue.field_bool = True
         queue.field_bytes = b"bytes"
         queue.field_enum = TestQueueBasic.TestEnum.TEST_ENUM_1
+        queue.repeated_int.append(24)
+        queue.repeated_int.append(37)
 
         arr = msg_to_arr(queue)
-        self.assertEqual(arr, [100, 77.89, "Hello World", True, b"bytes", 1, None, []])
+        self.assertEqual(
+            arr, [100, 77.89, "Hello World", True, b"bytes", 1, [24, 37], []]
+        )
 
         serial = serialize_msg2arr(queue)
-        self.assertEqual(serial, '[100,77.89,"Hello World",true,"bytes",1,null,[]]')
+        self.assertEqual(serial, '[100,77.89,"Hello World",true,"bytes",1,[24,37],[]]')
 
         self._test_deserialization(queue, arr, serial, TestQueueBasic)
 
@@ -86,6 +92,8 @@ class TestSerializer(TestCase):
         queue.field_bool = True
         queue.field_bytes = b"bytes"
         queue.field_enum = TestQueueBasic.TestEnum.TEST_ENUM_1
+        queue.repeated_int.append(24)
+        queue.repeated_int.append(37)
 
         subitem = TestQueueBasic.TestItem()
         subitem.item_field_int = 45
@@ -106,7 +114,7 @@ class TestSerializer(TestCase):
                 True,
                 b"bytes",
                 1,
-                None,
+                [24, 37],
                 [[45, 23.67, "Hello Inner World", True, b"bytes inner", 2]],
             ],
         )
@@ -114,7 +122,7 @@ class TestSerializer(TestCase):
         serial = serialize_msg2arr(queue)
         self.assertEqual(
             serial,
-            '[100,77.89,"Hello World",true,"bytes",1,null,[[45,23.67,"Hello Inner World",true,"bytes inner",2]]]',
+            '[100,77.89,"Hello World",true,"bytes",1,[24,37],[[45,23.67,"Hello Inner World",true,"bytes inner",2]]]',
         )
 
         self._test_deserialization(queue, arr, serial, TestQueueBasic)
@@ -176,4 +184,3 @@ class TestSerializer(TestCase):
         self.assertEqual(serial, '[100,77.89,"Hello World",false,"bytes",0,[]]')
 
         self._test_deserialization(queue, arr, serial, TestQueueAlt)
-"""

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -26,21 +26,21 @@ class TestSerializer(TestCase):
     def test_serialization_basic_default_empty(self):
         queue = TestQueueBasic()
         arr = msg_to_arr(queue)
-        self.assertEqual(arr, [None, None, None, None, None, None, []])
+        self.assertEqual(arr, [None, None, None, None, None, None, None, []])
 
         serial = serialize_msg2arr(queue)
-        self.assertEqual(serial, "[null,null,null,null,null,null,[]]")
+        self.assertEqual(serial, "[null,null,null,null,null,null,null,[]]")
 
         self._test_deserialization(queue, arr, serial, TestQueueBasic)
-
+"""
     def test_serialization_basic_default_empty_subitems(self):
         queue = TestQueueBasic()
         queue.items.append(TestQueueBasic.TestItem())
         arr = msg_to_arr(queue)
-        self.assertEqual(arr, [None, None, None, None, None, None, [None]])
+        self.assertEqual(arr, [None, None, None, None, None, None, None, [None]])
 
         serial = serialize_msg2arr(queue)
-        self.assertEqual(serial, "[null,null,null,null,null,null,[null]]")
+        self.assertEqual(serial, "[null,null,null,null,null,null,null,[null]]")
 
         self._test_deserialization(queue, arr, serial, TestQueueBasic)
 
@@ -54,10 +54,10 @@ class TestSerializer(TestCase):
         queue.field_enum = TestQueueBasic.TestEnum.TEST_ENUM_0
 
         arr = msg_to_arr(queue)
-        self.assertEqual(arr, [None, None, None, None, None, None, []])
+        self.assertEqual(arr, [None, None, None, None, None, None, None, []])
 
         serial = serialize_msg2arr(queue)
-        self.assertEqual(serial, "[null,null,null,null,null,null,[]]")
+        self.assertEqual(serial, "[null,null,null,null,null,null,null,[]]")
 
         self._test_deserialization(queue, arr, serial, TestQueueBasic)
 
@@ -71,10 +71,10 @@ class TestSerializer(TestCase):
         queue.field_enum = TestQueueBasic.TestEnum.TEST_ENUM_1
 
         arr = msg_to_arr(queue)
-        self.assertEqual(arr, [100, 77.89, "Hello World", True, b"bytes", 1, []])
+        self.assertEqual(arr, [100, 77.89, "Hello World", True, b"bytes", 1, None, []])
 
         serial = serialize_msg2arr(queue)
-        self.assertEqual(serial, '[100,77.89,"Hello World",true,"bytes",1,[]]')
+        self.assertEqual(serial, '[100,77.89,"Hello World",true,"bytes",1,null,[]]')
 
         self._test_deserialization(queue, arr, serial, TestQueueBasic)
 
@@ -106,6 +106,7 @@ class TestSerializer(TestCase):
                 True,
                 b"bytes",
                 1,
+                None,
                 [[45, 23.67, "Hello Inner World", True, b"bytes inner", 2]],
             ],
         )
@@ -113,7 +114,7 @@ class TestSerializer(TestCase):
         serial = serialize_msg2arr(queue)
         self.assertEqual(
             serial,
-            '[100,77.89,"Hello World",true,"bytes",1,[[45,23.67,"Hello Inner World",true,"bytes inner",2]]]',
+            '[100,77.89,"Hello World",true,"bytes",1,null,[[45,23.67,"Hello Inner World",true,"bytes inner",2]]]',
         )
 
         self._test_deserialization(queue, arr, serial, TestQueueBasic)
@@ -175,3 +176,4 @@ class TestSerializer(TestCase):
         self.assertEqual(serial, '[100,77.89,"Hello World",false,"bytes",0,[]]')
 
         self._test_deserialization(queue, arr, serial, TestQueueAlt)
+"""


### PR DESCRIPTION
```protobuf
syntax = "proto3";

message Message {
    repeated int32 field = 1;
}
```

```python
from message_pb2 import Message
from protobuf2arr import serialize_msg2arr

msg - Message()
msg.field.append(5)
msg.field.append(8)

print(serialize_msg2arr(msg))
```
```
[[5,8]]
```